### PR TITLE
Deploy to npm on a new Git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    tags: ['*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Publish package
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_CONFIG_TOKEN }}
+        run: bun publish --access public


### PR DESCRIPTION
I’ve set up a simple GitHub Actions workflow that will release a new version on npm for every Git tag. In future, we might also want to add some tests, but for now I think this should be enough.

---

@tonypconway I can’t seem to set Action secrets in the settings – at least [`admin` access is needed](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository). Could you perhaps bump my role? https://github.com/A-Edge/landing/settings/access

Alternatively, you can set it up yourself like this:

1. Go to https://www.npmjs.com/settings/tonypconway/tokens/granular-access-tokens/new
2. Set up a token name, some reasonable expiration date
3. Under **Packages and scopes** → **Permissions** select **Read and write**, then **Only select packages and scopes** → `browserslist-config-baseline`
4. Go to https://github.com/web-platform-dx/browserslist-config-baseline/settings/secrets/actions/new
5. Set **Name** to `NPM_CONFIG_TOKEN` and **Secret** to the token you just got